### PR TITLE
Remove session id from redirectURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,9 +162,11 @@ var sendResponse = function(ctx, err, session) {
             redirectURL.query.error = err;
         } else {
             // append user + session id to the redirect url
+            /* Cookie is set, I dont't want secret data in the url
             redirectURL.query.success = true;
             redirectURL.query.sid = session.id;
             redirectURL.query.uid = session.uid;
+            */
         }
 
         var redirectURLString = '';

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ var sendResponse = function(ctx, err, session) {
             redirectURL.query.error = err;
         } else {
             // append user + session id to the redirect url
-             redirectURL.query.success = true;
+            redirectURL.query.success = true;
             /* Cookie is set, I dont't want secret data in the url
             redirectURL.query.sid = session.id;
             redirectURL.query.uid = session.uid;

--- a/index.js
+++ b/index.js
@@ -162,8 +162,8 @@ var sendResponse = function(ctx, err, session) {
             redirectURL.query.error = err;
         } else {
             // append user + session id to the redirect url
+             redirectURL.query.success = true;
             /* Cookie is set, I dont't want secret data in the url
-            redirectURL.query.success = true;
             redirectURL.query.sid = session.id;
             redirectURL.query.uid = session.uid;
             */


### PR DESCRIPTION
Is there a reason for sid and uid in the redirectURL?
For me that looks like a security problem. 
sid and uid are in the referrer if external links are used. 