### PR TITLE
Fix for Deployd 0.8.0 (setting "set-cookie" header) 

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,6 +319,8 @@ AuthResource.prototype.handle = function (ctx, next) {
             }
 
             ctx.session.set({path: '/users', uid: user.id}).save(function(err, session) {
+                if(ctx.session.sid && ctx.res.cookies)
+                    if (ctx.res.cookies) ctx.res.cookies.set('sid', ctx.session.sid, {overwrite: true});
                 return sendResponse(ctx, err, session);
             });
         })(ctx.req, ctx.res, ctx.next||ctx.done);


### PR DESCRIPTION
Dpd-passport is broken in the latest Deployd version (v0.8.0 rc-2). After a successful authorization with a local strategy (username+password), the session cookie is never set.

This patch seem to resolve issue.
