### PR TITLE
ipepe - bugfix and readme clarification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 This custom resource type allows you to authorize your users using the powerful [Passport](http://passportjs.org).
 Currently, the following methods are supported for authentification:
 
-* **local** (i.e. username + password)
+* **local** (i.e. username + password) - ONLY HTTP-POST METHOD
 * **Twitter** (using Api v1.1)
 * **Facebook** (using OAuth)
 * **GitHub**
@@ -66,8 +66,10 @@ Note: You may supply the baseURL (your website's root) via the environment varia
 
 ### Usage
 
-Point your users to `/auth/{login,twitter,facebook,github,google}` to have them login (or signup) via the specified module.
+Point your users to `/auth/{twitter,facebook,github,google}` to have them login (or signup) via the specified module.
 After that, Auth-Passport completely takes over and redirects the users according to the OAuth(2) flow.
+
+Also You can use `/auth/login` to login on local user collection but it has to be POST method.
 
 ### Usage in Mobile Apps
 

--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ var sendResponse = function(ctx, err, disableSessionId) {
 }
 AuthResource.prototype.handle = function (ctx, next) {
     var config = this.config;
-    
+
     // globally handle logout
     if(ctx.url === '/logout') {
         if (ctx.res.cookies) ctx.res.cookies.set('sid', null, {overwrite: true});
@@ -310,7 +310,8 @@ AuthResource.prototype.handle = function (ctx, next) {
     } else {
         // nothing matched, sorry
         debug('no module found: ', parts[0]);
-        console.err(err);
+        //TODO: err doesn't exist in this context
+        //console.err(err);
         return sendResponse(ctx, 'bad credentials', config.disableSessionId);
     }
 };


### PR DESCRIPTION
There was a bug on console.error in line 313 in index.js file. The
variable err doesn’t exist in that context. I commented it out. Also
fixed misleading readme about local login method.